### PR TITLE
Bugfix: Fix potential XSS attack

### DIFF
--- a/src/Tags/Recaptcha.php
+++ b/src/Tags/Recaptcha.php
@@ -53,7 +53,7 @@ class Recaptcha extends Tags
     protected function v3()
     {
         $siteKey = config('recaptcha.recaptcha_v3.site_key');
-        $action = str_replace('-', '_', request()->path());
+        $action = e(str_replace('-', '_', request()->path()));
 
         return <<<SCRIPT
             <script type="text/javascript">


### PR DESCRIPTION
You have to escape the path property otherwise you could end up with something like this when visiting an URL like `/123/'*alert('xss')*'/789`.

```html
<script type="text/javascript">
      window.recaptchaV3 = {}
      window.recaptchaV3.siteKey = 'MYKEY'
      window.recaptchaV3.action = '123/'*alert('xss')*'/789.'
</script>
```

When adding the `e()` function around the `path()` function you fix potential XSS attacks