### PR TITLE
Extend Illuminate Controller instead of App Controller

### DIFF
--- a/src/Http/Controllers/RecaptchaController.php
+++ b/src/Http/Controllers/RecaptchaController.php
@@ -3,8 +3,8 @@
 namespace Anakadote\StatamicRecaptcha\Http\Controllers;
 
 use Anakadote\StatamicRecaptcha\Services\RecaptchaV3;
-use Illuminate\Routing\Controller;
 use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
 
 class RecaptchaController extends Controller
 {

--- a/src/Http/Controllers/RecaptchaController.php
+++ b/src/Http/Controllers/RecaptchaController.php
@@ -3,10 +3,10 @@
 namespace Anakadote\StatamicRecaptcha\Http\Controllers;
 
 use Anakadote\StatamicRecaptcha\Services\RecaptchaV3;
-use Illuminate\Routing\Controller as BaseController;
+use Illuminate\Routing\Controller;
 use Illuminate\Http\Request;
 
-class RecaptchaController extends BaseController
+class RecaptchaController extends Controller
 {
     /**
      * Verify a reCAPTCHA v3 token and action.

--- a/src/Http/Controllers/RecaptchaController.php
+++ b/src/Http/Controllers/RecaptchaController.php
@@ -3,10 +3,10 @@
 namespace Anakadote\StatamicRecaptcha\Http\Controllers;
 
 use Anakadote\StatamicRecaptcha\Services\RecaptchaV3;
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Http\Request;
 
-class RecaptchaController extends Controller
+class RecaptchaController extends BaseController
 {
     /**
      * Verify a reCAPTCHA v3 token and action.


### PR DESCRIPTION
Extend Illuminate\Routing\Controller instead the App Controller in the RecaptchaController.

This adheres to best practices and allows the use of the Add On in Applications where App is not the root namespace