### PR TITLE
fixed google action name constraint bug

### DIFF
--- a/config/recaptcha.php
+++ b/config/recaptcha.php
@@ -23,8 +23,7 @@ return [
         'threshold' => env('RECAPTCHA_V3_THRESHOLD', .5),
         'error_message' => 'Sorry, but you look like a robot.',
         'terms' => 'This website has implemented reCAPTCHA v3 and your use of reCAPTCHA v3 is subject to the <a href="https://www.google.com/policies/privacy/" target="_blank">Google Privacy Policy</a> and <a href="https://www.google.com/policies/terms/" target="_blank">Terms of Use</a>.',
-        'action_length' => env('RECAPTCHA_V3_ACTION_LENGTH', 85), // Because of 'formsubmission/' prefix, limit is 100
-        'action_shaver_type' => env('RECAPTCHA_V3_ACTION_SHAVER_TYPE', 'crop'), //crop, md5
+
         // In addition to performing the captcha verification when a form is submitted,
         // Statamic reCAPTCHA for v3 also runs on page load, and if it is determined
         // that the user is likely a bot, all forms on the page will be removed.

--- a/config/recaptcha.php
+++ b/config/recaptcha.php
@@ -23,8 +23,6 @@ return [
         'threshold' => env('RECAPTCHA_V3_THRESHOLD', .5),
         'error_message' => 'Sorry, but you look like a robot.',
         'terms' => 'This website has implemented reCAPTCHA v3 and your use of reCAPTCHA v3 is subject to the <a href="https://www.google.com/policies/privacy/" target="_blank">Google Privacy Policy</a> and <a href="https://www.google.com/policies/terms/" target="_blank">Terms of Use</a>.',
-        'action_length' => env('RECAPTCHA_V3_ACTION_LENGTH', 85), // Because of 'formsubmission/' prefix, limit is 100
-        'action_shaver_type' => env('RECAPTCHA_V3_ACTION_SHAVER_TYPE', 'crop'), //crop, md5
         // In addition to performing the captcha verification when a form is submitted,
         // Statamic reCAPTCHA for v3 also runs on page load, and if it is determined
         // that the user is likely a bot, all forms on the page will be removed.

--- a/config/recaptcha.php
+++ b/config/recaptcha.php
@@ -23,7 +23,8 @@ return [
         'threshold' => env('RECAPTCHA_V3_THRESHOLD', .5),
         'error_message' => 'Sorry, but you look like a robot.',
         'terms' => 'This website has implemented reCAPTCHA v3 and your use of reCAPTCHA v3 is subject to the <a href="https://www.google.com/policies/privacy/" target="_blank">Google Privacy Policy</a> and <a href="https://www.google.com/policies/terms/" target="_blank">Terms of Use</a>.',
-
+        'action_length' => env('RECAPTCHA_V3_ACTION_LENGTH', 85), // Because of 'formsubmission/' prefix, limit is 100
+        'action_shaver_type' => env('RECAPTCHA_V3_ACTION_SHAVER_TYPE', 'crop'), //crop, md5
         // In addition to performing the captcha verification when a form is submitted,
         // Statamic reCAPTCHA for v3 also runs on page load, and if it is determined
         // that the user is likely a bot, all forms on the page will be removed.

--- a/src/Tags/Recaptcha.php
+++ b/src/Tags/Recaptcha.php
@@ -56,9 +56,9 @@ class Recaptcha extends Tags
         $action = e(str_replace('-', '_', request()->path()));
         $verifyOnPageLoad = config('recaptcha.recaptcha_v3.verify_on_page_load', true) ? 'true' : 'false';
 
-        $actionLength = config('recaptcha.recaptcha_v3.action_length');
+        $actionLength = config('recaptcha.recaptcha_v3.action_length', 85);
         if (strlen($action) > $actionLength) {
-            $action = match (config('recaptcha.recaptcha_v3.action_shaver_type')) {
+            $action = match (config('recaptcha.recaptcha_v3.action_shaver_type', 'crop')) {
                 'crop' => substr($action, 0, $actionLength),
                 'md5' => md5($action),
                 default => $action,

--- a/src/Tags/Recaptcha.php
+++ b/src/Tags/Recaptcha.php
@@ -56,13 +56,8 @@ class Recaptcha extends Tags
         $action = e(str_replace('-', '_', request()->path()));
         $verifyOnPageLoad = config('recaptcha.recaptcha_v3.verify_on_page_load', true) ? 'true' : 'false';
 
-        $actionLength = config('recaptcha.recaptcha_v3.action_length', 85);
-        if (strlen($action) > $actionLength) {
-            $action = match (config('recaptcha.recaptcha_v3.action_shaver_type', 'crop')) {
-                'crop' => substr($action, 0, $actionLength),
-                'md5' => md5($action),
-                default => $action,
-            };
+        if (strlen($action) > 85) {
+            $action = substr($action, 0, 85);
         }
 
         return <<<SCRIPT

--- a/src/Tags/Recaptcha.php
+++ b/src/Tags/Recaptcha.php
@@ -56,6 +56,15 @@ class Recaptcha extends Tags
         $action = e(str_replace('-', '_', request()->path()));
         $verifyOnPageLoad = config('recaptcha.recaptcha_v3.verify_on_page_load', true) ? 'true' : 'false';
 
+        $actionLength = config('recaptcha.recaptcha_v3.action_length');
+        if (strlen($action) > $actionLength) {
+            $action = match (config('recaptcha.recaptcha_v3.action_shaver_type')) {
+                'crop' => substr($action, 0, $actionLength),
+                'md5' => md5($action),
+                default => $action,
+            };
+        }
+
         return <<<SCRIPT
             <script type="text/javascript">
               window.recaptchaV3 = {};

--- a/src/Tags/Recaptcha.php
+++ b/src/Tags/Recaptcha.php
@@ -53,17 +53,8 @@ class Recaptcha extends Tags
     protected function v3()
     {
         $siteKey = config('recaptcha.recaptcha_v3.site_key');
-        $action = e(str_replace('-', '_', request()->path()));
+        $action = e(substr(str_replace('-', '_', request()->path()), 0, 85));
         $verifyOnPageLoad = config('recaptcha.recaptcha_v3.verify_on_page_load', true) ? 'true' : 'false';
-
-        $actionLength = config('recaptcha.recaptcha_v3.action_length', 85);
-        if (strlen($action) > $actionLength) {
-            $action = match (config('recaptcha.recaptcha_v3.action_shaver_type', 'crop')) {
-                'crop' => substr($action, 0, $actionLength),
-                'md5' => md5($action),
-                default => $action,
-            };
-        }
 
         return <<<SCRIPT
             <script type="text/javascript">


### PR DESCRIPTION
When the endpoint path exceeds 85 characters (15 char 'formsubmission/', limit 100), Google throws this error.
<img width="545" alt="Ekran Resmi 2025-03-12 18 02 40" src="https://github.com/user-attachments/assets/5d7968a8-7ec6-47cb-bb71-b64d7828468a" />

My goal in this PR was to fix this error.
Thank you.