### PR TITLE
Remove redundant `curl_close()` functions

### DIFF
--- a/src/Services/RecaptchaV2.php
+++ b/src/Services/RecaptchaV2.php
@@ -23,7 +23,6 @@ class RecaptchaV2
         curl_setopt($ch, CURLOPT_POST, 0);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         $output = curl_exec($ch);
-        curl_close($ch);
 
         $result = json_decode($output);
 

--- a/src/Services/RecaptchaV3.php
+++ b/src/Services/RecaptchaV3.php
@@ -25,7 +25,6 @@ class RecaptchaV3
         curl_setopt($ch, CURLOPT_POST, 0);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         $output = curl_exec($ch);
-        curl_close($ch);
 
         $result = json_decode($output);
 


### PR DESCRIPTION
Removed unnecessary curl_close call after executing curl.  `curl_close` and `curl_share_close` functions are deprecated because they are no-op in PHP >= 8.0